### PR TITLE
Change in boundary condition (line 87).

### DIFF
--- a/Snake Game/snake.js
+++ b/Snake Game/snake.js
@@ -84,7 +84,7 @@ function init(){
 			var last_x = Math.round(W/cs);
 			var last_y = Math.round(H/cs);
 
-			if(this.cells[0].y<0 || this.cells[0].x < 0 || this.cells[0].x > last_x || this.cells[0].y > last_y){
+			if(this.cells[0].y<0 || this.cells[0].x < 0 || this.cells[0].x >= last_x || this.cells[0].y >= last_y){
 				game_over = true;
 			}
 


### PR DESCRIPTION
The last two OR ( || ) cases of 'if' condition at line 87 should have '>=" comparison instead of just '>' comparison. This is because, suppose the length of our snake is 5 boxes and we hit right boundary then as per '>' comparison then game gets over only when 1 box out of snake length (i.e. 5 boxes) crosses that boundary. But if we put '>=' comparison then the game gets over as soon as the snake touches the boundary. Similar case is with the bottom boundary.

You can see it here:  Snake represented by - ooooo ( length is 5)

Case 1: If we use '>' Comparison

OOOO|O

This is how the game gets over using '>' comparison.

Case 2: If we use '>=' comparison

OOOOO|

Same thing happens with bottom boundary.

Please check it out because the snake can even change its direction near the boundary with '>' comparison.